### PR TITLE
중기예보전망 조회 API 구현 / ServiceKey 에러, DataBind 에러 미해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.15.2'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/midfcst/weatherfcst/application/MidFcstReq.java
+++ b/src/main/java/com/midfcst/weatherfcst/application/MidFcstReq.java
@@ -1,0 +1,14 @@
+package com.midfcst.weatherfcst.application;
+
+import lombok.Data;
+
+@Data
+public class MidFcstReq {
+
+    private String serviceKey;
+    private String pageNo;
+    private String numOfRows;
+    private String dataType;
+    private String stnId;
+    private String tmFc;
+}

--- a/src/main/java/com/midfcst/weatherfcst/application/MidFcstRes.java
+++ b/src/main/java/com/midfcst/weatherfcst/application/MidFcstRes.java
@@ -1,0 +1,48 @@
+package com.midfcst.weatherfcst.application;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Data;
+
+public class MidFcstRes {
+
+    private Response response;
+
+    @Data
+    public static class Response {
+
+        private Header header;
+        private Body body;
+    }
+
+    @Data
+    public static class Header {
+
+        private String resultCode;
+        private String resultMsg;
+    }
+
+    @Data
+    public static class Body {
+
+        private String dataType;
+        private Items items;
+        private int pageNo;
+        private int numOfRows;
+        private int totalCount;
+    }
+
+    @Data
+    public static class Items {
+
+        @JsonProperty("item") // JSON 응답의 key에 매핑
+        private List<Item> item;
+    }
+
+    @Data
+    public static class Item {
+
+        @JsonProperty("wfSv") // JSON 응답의 key에 매핑
+        private String weatherSummary;
+    }
+}

--- a/src/main/java/com/midfcst/weatherfcst/common/RestTemplateConfig.java
+++ b/src/main/java/com/midfcst/weatherfcst/common/RestTemplateConfig.java
@@ -1,0 +1,17 @@
+package com.midfcst.weatherfcst.common;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getMessageConverters().add(new MappingJackson2XmlHttpMessageConverter());
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/midfcst/weatherfcst/controller/WeatherController.java
+++ b/src/main/java/com/midfcst/weatherfcst/controller/WeatherController.java
@@ -1,0 +1,30 @@
+package com.midfcst.weatherfcst.controller;
+
+import com.midfcst.weatherfcst.service.WeatherService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weather")
+@Slf4j
+public class WeatherController {
+
+    private final WeatherService weatherService;
+
+    @GetMapping(value = "/mid-fcst")
+    public ResponseEntity<String> getMidFcst(
+        @RequestParam String pageNo,
+        @RequestParam String numOfRows,
+        @RequestParam String stnId,
+        @RequestParam String tmFc
+    ) {
+        log.info("Controller : getMidFcst");
+        return weatherService.getMidFcst(pageNo, numOfRows, stnId, tmFc);
+    }
+}

--- a/src/main/java/com/midfcst/weatherfcst/service/WeatherService.java
+++ b/src/main/java/com/midfcst/weatherfcst/service/WeatherService.java
@@ -1,0 +1,45 @@
+package com.midfcst.weatherfcst.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WeatherService {
+
+    private final RestTemplate restTemplate;
+    private final String baseUrl = "http://apis.data.go.kr/1360000";
+    private final String type = "JSON";
+    @Value("${service-key}")
+    private String serviceKey;
+
+    public ResponseEntity<String> getMidFcst(String pageNo, String numOfRows, String stnId,
+        String tmFc) {
+        log.info("Service : getMidFcst");
+
+        String uri = UriComponentsBuilder.fromHttpUrl(baseUrl + "/MidFcstInfoService/getMidFcst")
+            .queryParam("serviceKey", serviceKey)
+            .queryParam("dataType", type)
+            .queryParam("pageNo", pageNo)
+            .queryParam("numOfRows", numOfRows)
+            .queryParam("stnId", stnId)
+            .queryParam("tmFc", tmFc)
+            .toUriString();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Accept", "application/json");
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=weather-fcst

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: WeatherFcst
+
+service-key: 8n60ZscywcCaGclSDiuVl6WGzU3W3x0dA%2BmI6G%2BykDp5%2Fspt%2BE3TuWzmQXqCbSpt62wOobx3QcCgjgYLVAAN4w%3D%3D


### PR DESCRIPTION
- 코드의 간결성을 위해 공식 문서의 HttpURLConnection 가 아닌 RestTemplate 사용.
- ServiceKey 에러 : 여러 시도를 해 보았으나 해결 실패.
- DataBind 에러 : 문서에는 DataType 변수에 따라 XML/JSON을 둘다 지원한다고 나와있지만, XML로만 응답이 돌아오는 에러.